### PR TITLE
Added requests as dependency and URL schema enforcing + zoomeye and auto icon finding

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ this script will help you find favicon hashes which you can use in shodan to wid
 
 <b>Example:<b>
 ><br>root@Kali:~/Desktop/Favicon_Hash# python3 get_favicon_hash.py  
-><br>Enter Favicon URL to get the mmh3-HASH: https://facebook.com/favicon.ico  
+><br>Enter URL to get the mmh3-HASH: https://facebook.com/
 ><br>-1321378357  
 ><br>Now Use this on Shodan For Searching,http.favicon.hash:-1321378357
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ this script will help you find favicon hashes which you can use in shodan to wid
 
 <b>Example:<b>
 ><br>root@Kali:~/Desktop/Favicon_Hash# python3 get_favicon_hash.py  
-><br>Enter URL to get the mmh3-HASH: https://facebook.com/
+><br>Enter URL to get the mmh3-HASH: https://facebook.com/favicon.ico
 ><br>-1321378357  
 ><br>Now Use this on Shodan For Searching,http.favicon.hash:-1321378357
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 this script will help you find favicon hashes which you can use in shodan to widened your attack surface
 
 <b>Pre-requisite:</b>
->pip3 install mmh3 requests
+>pip3 install mmh3 requests favicon
 
 <b>Usage:</b>
 >python3 get_favicon_hash.py URL containing favicon.ico

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 this script will help you find favicon hashes which you can use in shodan to widened your attack surface
 
 <b>Pre-requisite:</b>
->pip3 install mmh3
+>pip3 install mmh3 requests
 
 <b>Usage:</b>
 >python3 get_favicon_hash.py URL containing favicon.ico

--- a/get_favicon_hash.py
+++ b/get_favicon_hash.py
@@ -34,3 +34,8 @@ print(
     "\t or press here: https://www.shodan.io/search?query=http.favicon.hash%3A"
     + str(hash)
 )
+
+print("Use this on Zoomeye For Searching,iconhash:\"" + str(hash)+"\"")
+print(
+    "\t or press here: https://www.zoomeye.org/searchResult?q=iconhash%3A%20%22"+str(hash)+"%22"
+)

--- a/get_favicon_hash.py
+++ b/get_favicon_hash.py
@@ -4,7 +4,7 @@ from pathlib import Path
 user_agent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.47 Safari/537.36'
 headers = {'User-Agent': user_agent}
 
-inp = input("Enter Favicon URL to get the mmh3-HASH: ")
+inp = input("Enter URL to get the mmh3-HASH: ")
 # check if the URL has a generic schema.
 # Since we don't know the schema, we will check for the presence of :// in the URL.
 while inp.find("://") == -1:

--- a/get_favicon_hash.py
+++ b/get_favicon_hash.py
@@ -1,9 +1,11 @@
 import requests,mmh3,base64
 inp = input("Enter Favicon URL to get the mmh3-HASH: ") 
+#check if the URL has a generic schema.
+#Since we don't know the schema, we will check for the presence of :// in the URL.
+while inp.find("://") == -1:
+    inp = input("Enter a valid URL (with schema): ")
 response = requests.get(inp)
 favicon = base64.encodebytes(response.content)
 hash = mmh3.hash(favicon)
 print (hash)
 print ("Now Use this on Shodan For Searching,http.favicon.hash:" + str(hash))
-
-	

--- a/get_favicon_hash.py
+++ b/get_favicon_hash.py
@@ -17,15 +17,20 @@ if (
     and not inp.lower().endswith(".gif")
 ):
     icons = favicon.get(inp, headers=headers)
+    if len(icons) == 0:
+        print("No favicon found.")
+        print("Try to insert the direct url, such as {}/favicon.ico".format(inp))
+        exit()
+    print(icons)
     icon = icons[0]
     favicon_url = icon.url
 else:
     favicon_url = inp
-#get the icon from the favicon url.
+# get the icon from the favicon url.
 response = requests.get(favicon_url, headers=headers)
-#convert to base64
+# convert to base64
 icon_data = base64.encodebytes(response.content)
-#hash it
+# hash it
 hash = mmh3.hash(icon_data)
 
 print(hash)
@@ -35,7 +40,9 @@ print(
     + str(hash)
 )
 
-print("Use this on Zoomeye For Searching,iconhash:\"" + str(hash)+"\"")
+print('Use this on Zoomeye For Searching,iconhash:"' + str(hash) + '"')
 print(
-    "\t or press here: https://www.zoomeye.org/searchResult?q=iconhash%3A%20%22"+str(hash)+"%22"
+    "\t or press here: https://www.zoomeye.org/searchResult?q=iconhash%3A%20%22"
+    + str(hash)
+    + "%22"
 )

--- a/get_favicon_hash.py
+++ b/get_favicon_hash.py
@@ -1,11 +1,12 @@
-import requests,mmh3,base64
-inp = input("Enter Favicon URL to get the mmh3-HASH: ") 
-#check if the URL has a generic schema.
-#Since we don't know the schema, we will check for the presence of :// in the URL.
+import requests, mmh3, base64
+
+inp = input("Enter Favicon URL to get the mmh3-HASH: ")
+# check if the URL has a generic schema.
+# Since we don't know the schema, we will check for the presence of :// in the URL.
 while inp.find("://") == -1:
     inp = input("Enter a valid URL (with schema): ")
 response = requests.get(inp)
 favicon = base64.encodebytes(response.content)
 hash = mmh3.hash(favicon)
-print (hash)
-print ("Now Use this on Shodan For Searching,http.favicon.hash:" + str(hash))
+print(hash)
+print("Now Use this on Shodan For Searching,http.favicon.hash:" + str(hash))

--- a/get_favicon_hash.py
+++ b/get_favicon_hash.py
@@ -1,20 +1,36 @@
 import requests, mmh3, base64
-import favicon 
-from pathlib import Path
-user_agent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.47 Safari/537.36'
-headers = {'User-Agent': user_agent}
+import favicon
+
+user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.47 Safari/537.36"
+headers = {"User-Agent": user_agent}
 
 inp = input("Enter URL to get the mmh3-HASH: ")
 # check if the URL has a generic schema.
 # Since we don't know the schema, we will check for the presence of :// in the URL.
 while inp.find("://") == -1:
     inp = input("Enter a valid URL (with schema): ")
-icons = favicon.get(inp, headers=headers)
-icon = icons[0]
-response = requests.get(icon.url, headers=headers)
+# if url is already favicon file (.ico, .jpg, .png or .gif), skip the reconnaissance.
+if (
+    not inp.lower().endswith(".ico")
+    and not inp.lower().endswith(".jpg")
+    and not inp.lower().endswith(".png")
+    and not inp.lower().endswith(".gif")
+):
+    icons = favicon.get(inp, headers=headers)
+    icon = icons[0]
+    favicon_url = icon.url
+else:
+    favicon_url = inp
+#get the icon from the favicon url.
+response = requests.get(favicon_url, headers=headers)
+#convert to base64
 icon_data = base64.encodebytes(response.content)
+#hash it
 hash = mmh3.hash(icon_data)
 
 print(hash)
 print("Now Use this on Shodan For Searching,http.favicon.hash:" + str(hash))
-print("\t or press here: https://www.shodan.io/search?query=http.favicon.hash%3A" + str(hash))
+print(
+    "\t or press here: https://www.shodan.io/search?query=http.favicon.hash%3A"
+    + str(hash)
+)

--- a/get_favicon_hash.py
+++ b/get_favicon_hash.py
@@ -1,12 +1,20 @@
 import requests, mmh3, base64
+import favicon 
+from pathlib import Path
+user_agent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.47 Safari/537.36'
+headers = {'User-Agent': user_agent}
 
 inp = input("Enter Favicon URL to get the mmh3-HASH: ")
 # check if the URL has a generic schema.
 # Since we don't know the schema, we will check for the presence of :// in the URL.
 while inp.find("://") == -1:
     inp = input("Enter a valid URL (with schema): ")
-response = requests.get(inp)
-favicon = base64.encodebytes(response.content)
-hash = mmh3.hash(favicon)
+icons = favicon.get(inp, headers=headers)
+icon = icons[0]
+response = requests.get(icon.url, headers=headers)
+icon_data = base64.encodebytes(response.content)
+hash = mmh3.hash(icon_data)
+
 print(hash)
 print("Now Use this on Shodan For Searching,http.favicon.hash:" + str(hash))
+print("\t or press here: https://www.shodan.io/search?query=http.favicon.hash%3A" + str(hash))


### PR DESCRIPTION
The readme was missing the "requests" requirement for pip3 install.

The URL schema validation is not implemented, resulting in a request error (e.g., I may use mysite.com when I should use https:// mysite.com).
I have implemented a fairly relaxed check, since it simply checks for :// (still better than nothing).

Added also zoomeye results and (by using "favicon" library) the possiblity of auto parsing the favicon just by using the site url.